### PR TITLE
Stack education section items on mobile and adopt black/zinc/cyan theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # cjhirashi.github.io
+
+Portafolio profesional de Carlos Jiménez Hirashi.
+
+Este repositorio contiene un sitio web estático construido solo con **HTML** y **CSS**.
+
+## Archivos principales
+
+- `index.html`: página principal que carga las demás secciones.
+- `habilidades.html`: fragmento con la sección de habilidades.
+- `proyectos.html`: fragmento con la sección de proyectos.
+- `educacion.html`: fragmento con la sección de educación.
+- `styles.css`: estilos y diseño responsivo.
+
+## Visualización local
+
+No se requieren dependencias ni compilación. Para ver el sitio en tu equipo, abre `index.html` en el navegador:
+
+```bash
+# macOS
+open index.html
+
+# Linux
+xdg-open index.html
+```
+
+Las secciones de habilidades, proyectos y educación se almacenan en archivos independientes y se insertan dinámicamente en `index.html` con JavaScript para facilitar su actualización.
+
+Las secciones se adaptan automáticamente a una sola columna en pantallas de 720 px o menos.

--- a/educacion.html
+++ b/educacion.html
@@ -1,0 +1,17 @@
+<section id="educacion" aria-labelledby="edu-title">
+  <h2 class="section-title">🎓 Educación</h2>
+  <div class="grid-2">
+    <div class="meta-card">
+      <b>TripleTen</b>
+      <div class="small">Bootcamp en Ciencia de Datos — 2025 (En curso)</div>
+    </div>
+    <div class="meta-card">
+      <b>Formación complementaria</b>
+      <div class="small">Udemy: Python, Machine Learning, JavaScript/TypeScript, HTML/CSS</div>
+    </div>
+    <div class="meta-card">
+      <b>Universidad Tecnológia Tula Tepeji</b>
+      <div class="small">Electrónica y Automatización</div>
+    </div>
+  </div>
+</section>

--- a/habilidades.html
+++ b/habilidades.html
@@ -1,0 +1,37 @@
+<section id="habilidades" aria-labelledby="skills-title">
+  <h2 class="section-title">🧠 Habilidades</h2>
+  <div class="grid-3">
+    <div class="meta-card">
+      <div class="small">Lenguajes</div>
+      <div class="chips">
+        <span class="chip">Python</span>
+        <span class="chip">SQL</span>
+        <span class="chip">JavaScript</span>
+        <span class="chip">TypeScript</span>
+        <span class="chip">HTML</span>
+        <span class="chip">CSS</span>
+      </div>
+    </div>
+    <div class="meta-card">
+      <div class="small">Librerías y Frameworks</div>
+      <div class="chips">
+        <span class="chip">pandas</span>
+        <span class="chip">NumPy</span>
+        <span class="chip">Matplotlib</span>
+        <span class="chip">scikit-learn</span>
+        <span class="chip">Seaborn</span>
+        <span class="chip">Plotly</span>
+      </div>
+    </div>
+    <div class="meta-card">
+      <div class="small">Bases de datos y herramientas</div>
+      <div class="chips">
+        <span class="chip">PostgreSQL</span>
+        <span class="chip">Git</span>
+        <span class="chip">GitHub</span>
+        <span class="chip">Jupyter</span>
+        <span class="chip">VS Code</span>
+      </div>
+    </div>
+  </div>
+</section>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Portafolio | Carlos Jiménez</title>
   <meta name="description" content="Portafolio profesional de Carlos Jiménez Hirashi — Científico de Datos Jr., Python, SQL, Machine Learning y Automatización HVAC." />
-  <meta name="theme-color" content="#0ea5e9" />
+  <meta name="theme-color" content="#06b6d4" />
 
   <!-- Fuente moderna y legible -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -83,105 +83,8 @@
         </aside>
       </div>
     </section>
-
-    <!-- HABILIDADES -->
-    <section id="habilidades" aria-labelledby="skills-title">
-      <h2 class="section-title">🧠 Habilidades</h2>
-      <div class="grid-3">
-        <div class="meta-card">
-          <div class="small">Lenguajes</div>
-          <div class="chips">
-            <span class="chip">Python</span>
-            <span class="chip">SQL</span>
-            <span class="chip">JavaScript</span>
-            <span class="chip">TypeScript</span>
-            <span class="chip">HTML</span>
-            <span class="chip">CSS</span>
-          </div>
-        </div>
-        <div class="meta-card">
-          <div class="small">Librerías y Frameworks</div>
-          <div class="chips">
-            <span class="chip">pandas</span>
-            <span class="chip">NumPy</span>
-            <span class="chip">Matplotlib</span>
-            <span class="chip">scikit-learn</span>
-            <span class="chip">Seaborn</span>
-            <span class="chip">Plotly</span>
-          </div>
-        </div>
-        <div class="meta-card">
-          <div class="small">Bases de datos y herramientas</div>
-          <div class="chips">
-            <span class="chip">PostgreSQL</span>
-            <span class="chip">Git</span>
-            <span class="chip">GitHub</span>
-            <span class="chip">Jupyter</span>
-            <span class="chip">VS Code</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- PROYECTOS -->
-    <section id="proyectos" aria-labelledby="projects-title">
-      <h2 class="section-title">🧩 Proyectos</h2>
-      <div class="cards">
-        <!-- Proyecto 1 -->
-        <article class="card">
-          <div class="thumb" role="img" aria-label="Visualización de datos"></div>
-          <div class="card-body">
-            <h3>Análisis de Tarifas de Prepago (Megaline) -Sprint 5</h3>
-            <p class="muted">Proyecto del Sprint 5 en TripleTen que analiza datos de clientes de Megaline para identificar qué tarifa, Surf o Ultimate, genera más ingresos y apoyar decisiones de marketing. Se usan datos de 500 clientes en 2018 con información de llamadas, SMS, internet y plan contratado.</p>
-            <div class="tags">
-              <span class="tag">Python</span>
-              <span class="tag">pandas</span>
-              <span class="tag">Matplotlib</span>
-              <span class="tag">Jupyter</span>
-            </div>
-            <div class="card-actions">
-              <a class="btn" href="https://github.com/cjhirashi/proyecto-sprint-5" target="_blank" rel="noopener">Código</a>
-            </div>
-          </div>
-        </article>
-
-        <!-- Proyecto 2 -->
-        <article class="card">
-          <div class="thumb" role="img" aria-label="Asistente GPT"></div>
-          <div class="card-body">
-            <h3>Análisis de Ventas de Videojuegos - Sprint 6</h3>
-            <p class="muted">Análisis de ventas de videojuegos a nivel global (Sprint 6 - TripleTen). Estudio de patrones de éxito en plataformas, géneros y regiones, con pruebas de hipótesis estadísticas para apoyar decisiones estratégicas de mercado.</p>
-            <div class="tags">
-              <span class="tag">Python</span>
-              <span class="tag">pandas</span>
-              <span class="tag">Jupyter</span>
-            </div>
-            <div class="card-actions">
-              <a class="btn" href="https://github.com/cjhirashi/proyecto-sprint-6" target="_blank" rel="noopener">Código</a>
-            </div>
-          </div>
-        </article>
-
-        <!-- Proyecto 3 -->
-        <article class="card">
-          <div class="thumb" role="img" aria-label="Análisis de datos"></div>
-          <div class="card-body">
-            <h3>Streamlit Dashboard - Anuncios de Vehículos Usados</h3>
-            <p class="muted">Aplicación web interactiva en Streamlit para analizar anuncios de autos usados en EE.UU. Permite explorar la relación entre kilometraje (odometer) y precio (price), con una interfaz clara y visualmente atractiva para el análisis de mercado.</p>
-            <div class="tags">
-              <span class="tag">Python</span>
-              <span class="tag">pandas</span>
-              <span class="tag">Matplotlib</span>
-            </div>
-            <div class="card-actions">
-              <a class="btn" href="https://github.com/cjhirashi/dashboard-sprint-7" target="_blank" rel="noopener">Código</a>
-              <a class="btn alt" href="https://dashboard-sprint-7.onrender.com" aria-disabled="true">Demo</a>
-            </div>
-          </div>
-        </article>
-      </div>
-      <p class="small muted" style="margin-top:.6rem">Tip: puedes reemplazar las imágenes de portada (Unsplash) con capturas de tus notebooks o dashboards.</p>
-    </section>
+    <div data-include="habilidades.html"></div>
+    <div data-include="proyectos.html"></div>
 
     <!-- EXPERIENCIA -->
     <section id="experiencia" aria-labelledby="exp-title">
@@ -226,25 +129,7 @@
         </div>
       </div>
     </section>
-
-    <!-- EDUCACIÓN -->
-    <section id="educacion" aria-labelledby="edu-title">
-      <h2 class="section-title">🎓 Educación</h2>
-      <div class="grid-2">
-        <div class="meta-card">
-          <b>TripleTen</b>
-          <div class="small">Bootcamp en Ciencia de Datos — 2025 (En curso)</div>
-        </div>
-        <div class="meta-card">
-          <b>Formación complementaria</b>
-          <div class="small">Udemy: Python, Machine Learning, JavaScript/TypeScript, HTML/CSS</div>
-        </div>
-        <div class="meta-card">
-          <b>Universidad Tecnológia Tula Tepeji</b>
-          <div class="small">Electrónica y Automatización</div>
-        </div>
-      </div>
-    </section>
+    <div data-include="educacion.html"></div>
 
     <!-- CONTACTO -->
     <section id="contacto" aria-labelledby="contact-title">
@@ -281,6 +166,12 @@
       if (e.key === 'Escape') {
         document.querySelector('.menu')?.classList.remove('show');
       }
+    });
+    // carga de secciones externas
+    document.querySelectorAll('[data-include]').forEach(el => {
+      fetch(el.getAttribute('data-include'))
+        .then(res => res.text())
+        .then(html => { el.outerHTML = html; });
     });
   </script>
 </body>

--- a/proyectos.html
+++ b/proyectos.html
@@ -1,0 +1,58 @@
+<section id="proyectos" aria-labelledby="projects-title">
+  <h2 class="section-title">🧩 Proyectos</h2>
+  <div class="cards">
+    <!-- Proyecto 1 -->
+    <article class="card">
+      <div class="thumb" role="img" aria-label="Visualización de datos"></div>
+      <div class="card-body">
+        <h3>Análisis de Tarifas de Prepago (Megaline) -Sprint 5</h3>
+        <p class="muted">Proyecto del Sprint 5 en TripleTen que analiza datos de clientes de Megaline para identificar qué tarifa, Surf o Ultimate, genera más ingresos y apoyar decisiones de marketing. Se usan datos de 500 clientes en 2018 con información de llamadas, SMS, internet y plan contratado.</p>
+        <div class="tags">
+          <span class="tag">Python</span>
+          <span class="tag">pandas</span>
+          <span class="tag">Matplotlib</span>
+          <span class="tag">Jupyter</span>
+        </div>
+        <div class="card-actions">
+          <a class="btn" href="https://github.com/cjhirashi/proyecto-sprint-5" target="_blank" rel="noopener">Código</a>
+        </div>
+      </div>
+    </article>
+
+    <!-- Proyecto 2 -->
+    <article class="card">
+      <div class="thumb" role="img" aria-label="Asistente GPT"></div>
+      <div class="card-body">
+        <h3>Análisis de Ventas de Videojuegos - Sprint 6</h3>
+        <p class="muted">Análisis de ventas de videojuegos a nivel global (Sprint 6 - TripleTen). Estudio de patrones de éxito en plataformas, géneros y regiones, con pruebas de hipótesis estadísticas para apoyar decisiones estratégicas de mercado.</p>
+        <div class="tags">
+          <span class="tag">Python</span>
+          <span class="tag">pandas</span>
+          <span class="tag">Jupyter</span>
+        </div>
+        <div class="card-actions">
+          <a class="btn" href="https://github.com/cjhirashi/proyecto-sprint-6" target="_blank" rel="noopener">Código</a>
+        </div>
+      </div>
+    </article>
+
+    <!-- Proyecto 3 -->
+    <article class="card">
+      <div class="thumb" role="img" aria-label="Análisis de datos"></div>
+      <div class="card-body">
+        <h3>Streamlit Dashboard - Anuncios de Vehículos Usados</h3>
+        <p class="muted">Aplicación web interactiva en Streamlit para analizar anuncios de autos usados en EE.UU. Permite explorar la relación entre kilometraje (odometer) y precio (price), con una interfaz clara y visualmente atractiva para el análisis de mercado.</p>
+        <div class="tags">
+          <span class="tag">Python</span>
+          <span class="tag">pandas</span>
+          <span class="tag">Matplotlib</span>
+        </div>
+        <div class="card-actions">
+          <a class="btn" href="https://github.com/cjhirashi/dashboard-sprint-7" target="_blank" rel="noopener">Código</a>
+          <a class="btn alt" href="https://dashboard-sprint-7.onrender.com" aria-disabled="true">Demo</a>
+        </div>
+      </div>
+    </article>
+  </div>
+  <p class="small muted" style="margin-top:.6rem">Tip: puedes reemplazar las imágenes de portada (Unsplash) con capturas de tus notebooks o dashboards.</p>
+</section>

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
-  --bg: #0b1220;
-  --surface: #0f172a;
-  --surface-2: #111827;
-  --text: #e5e7eb;
-  --text-link: rgba(56,189,248,.6);
-  --text-link-hover: rgba(56,189,248,.85);
-  --muted: #9ca3af;
-  --primary: #0ea5e9;
-  --primary-2: #38bdf8;
-  --accent: #22c55e;
-  --card: #0b1220;
-  --ring: rgba(56,189,248,.4);
-  --shadow: 0 10px 25px rgba(2,6,23,.35);
+  --bg: #000;
+  --surface: #18181b;
+  --surface-2: #27272a;
+  --text: #e4e4e7;
+  --text-link: rgba(6,182,212,.6);
+  --text-link-hover: rgba(6,182,212,.85);
+  --muted: #a1a1aa;
+  --primary: #06b6d4;
+  --primary-2: #22d3ee;
+  --accent: #06b6d4;
+  --card: #000;
+  --ring: rgba(6,182,212,.4);
+  --shadow: 0 10px 25px rgba(0,0,0,.35);
   --radius: 18px;
   --radius-sm: 12px;
   --radius-lg: 26px;
@@ -23,8 +23,8 @@ html, body { height: 100%; }
 body {
   margin: 0;
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  background: radial-gradient(1200px 600px at 20% -10%, rgba(56,189,248,.15), rgba(34,197,94,.08) 40%, transparent 60%),
-              linear-gradient(180deg, #0a0f1d, #0b1220 35%);
+  background: radial-gradient(1200px 600px at 20% -10%, rgba(6,182,212,.15), rgba(63,63,70,.08) 40%, transparent 60%),
+              linear-gradient(180deg, #000, #18181b 35%);
   background-attachment: fixed;
   background-repeat: no-repeat;
   background-size: cover;
@@ -39,8 +39,8 @@ body {
 header {
   position: sticky; top: 0; z-index: 50;
   backdrop-filter: blur(12px);
-  background: linear-gradient(180deg, rgba(15,23,42,.85), rgba(15,23,42,.6));
-  border-bottom: 1px solid rgba(148,163,184,.12);
+  background: linear-gradient(180deg, rgba(24,24,27,.85), rgba(24,24,27,.6));
+  border-bottom: 1px solid rgba(82,82,91,.12);
 }
 a {
   color: var(--text-link);
@@ -55,42 +55,42 @@ a:hover, a:focus {
 .brand { display:flex; align-items:center; gap:.75rem; text-decoration:none; color:var(--text); }
 .brand-logo {
   width:40px; height:40px; border-radius:12px;
-  background: radial-gradient(circle at 30% 30%, var(--primary-2), var(--primary) 50%, #0369a1 70%);
-  box-shadow: inset 0 0 20px rgba(56,189,248,.35), 0 10px 20px rgba(2,6,23,.45);
+  background: radial-gradient(circle at 30% 30%, var(--primary-2), var(--primary) 50%, #0891b2 70%);
+  box-shadow: inset 0 0 20px rgba(6,182,212,.35), 0 10px 20px rgba(0,0,0,.45);
 }
 .brand h1 { font-size:1.05rem; margin:0; font-weight:700; letter-spacing:.3px; }
 
 .menu { display:flex; align-items:center; gap: 1rem; }
 .menu a { color: var(--muted); text-decoration:none; font-weight:500; padding:.5rem .75rem; border-radius:10px; }
-.menu a:hover, .menu a:focus { color: var(--text); background: rgba(56,189,248,.08); outline: none; }
+.menu a:hover, .menu a:focus { color: var(--text); background: rgba(6,182,212,.08); outline: none; }
 
 .menu-toggle { display:none; background:transparent; border:none; color:var(--text); font-size:1.25rem; }
 
 /* Hero */
 .hero { padding: 4.5rem 0 3rem; }
 .hero-grid { display:grid; grid-template-columns: 1.2fr .8fr; gap:2rem; align-items:center; }
-.kicker { display:inline-flex; align-items:center; gap:.5rem; font-size:.85rem; color:var(--primary-2); background: rgba(56,189,248,.08); border:1px solid rgba(56,189,248,.25); padding:.35rem .6rem; border-radius:999px; }
+.kicker { display:inline-flex; align-items:center; gap:.5rem; font-size:.85rem; color:var(--primary-2); background: rgba(6,182,212,.08); border:1px solid rgba(6,182,212,.25); padding:.35rem .6rem; border-radius:999px; }
 .title { font-size: clamp(1.4rem, 3.6vw, 3rem); line-height:1.15; margin:.75rem 0; font-weight:800; }
 .subtitle { color:var(--muted); font-size:1.05rem; max-width:56ch; }
 
 .cta { display:flex; gap:.75rem; margin-top:1.2rem; flex-wrap:wrap; }
 .btn {
   display:inline-flex; align-items:center; gap:.5rem; text-decoration:none; font-weight:600;
-  padding:.8rem 1rem; border-radius:12px; border:1px solid rgba(148,163,184,.18);
-  background: linear-gradient(180deg, rgba(56,189,248,.15), rgba(56,189,248,.05)); color: var(--text);
+  padding:.8rem 1rem; border-radius:12px; border:1px solid rgba(82,82,91,.18);
+  background: linear-gradient(180deg, rgba(6,182,212,.15), rgba(6,182,212,.05)); color: var(--text);
   box-shadow: var(--shadow);
 }
-.btn:hover { transform: translateY(-1px); box-shadow: 0 14px 30px rgba(2,6,23,.45); }
-.btn.alt { background: linear-gradient(180deg, rgba(34,197,94,.15), rgba(34,197,94,.05)); }
+.btn:hover { transform: translateY(-1px); box-shadow: 0 14px 30px rgba(0,0,0,.45); }
+.btn.alt { background: linear-gradient(180deg, rgba(63,63,70,.15), rgba(63,63,70,.05)); }
 
 .hero-card {
-  background: linear-gradient(180deg, rgba(15,23,42,.9), rgba(2,6,23,.85));
-  border: 1px solid rgba(148,163,184,.18);
+  background: linear-gradient(180deg, rgba(24,24,27,.9), rgba(0,0,0,.85));
+  border: 1px solid rgba(82,82,91,.18);
   border-radius: var(--radius-lg);
   padding: 1.25rem; box-shadow: var(--shadow);
 }
 .hero-card .row { display:grid; grid-template-columns: 1fr 1fr; gap:.75rem; }
-.stat { background: rgba(2,6,23,.6); border:1px solid rgba(148,163,184,.15); padding:.9rem; border-radius:14px; }
+.stat { background: rgba(0,0,0,.6); border:1px solid rgba(82,82,91,.15); padding:.9rem; border-radius:14px; }
 .stat b { display:block; font-size:1.1rem; }
 .small { color: var(--muted); font-size:.9rem; }
 
@@ -100,38 +100,38 @@ section { padding: 2.5rem 0 0; }
 .section-grid { display:grid; grid-template-columns: repeat(12, 1fr); gap:1.2rem; }
 
 /* Sobre mí */
-.about { grid-column: span 7; background: linear-gradient(180deg, rgba(2,6,23,.7), rgba(15,23,42,.75)); border:1px solid rgba(148,163,184,.15); border-radius: var(--radius); padding:1rem; }
-.about p { margin:.5rem 0; color: #d1d5db; }
+.about { grid-column: span 7; background: linear-gradient(180deg, rgba(0,0,0,.7), rgba(24,24,27,.75)); border:1px solid rgba(82,82,91,.15); border-radius: var(--radius); padding:1rem; }
+.about p { margin:.5rem 0; color: #d4d4d8; }
 .meta { grid-column: span 5; display:grid; gap:.75rem; }
-.meta-card { background: rgba(2,6,23,.6); border:1px solid rgba(148,163,184,.15); border-radius: var(--radius); padding: .9rem; }
+.meta-card { background: rgba(0,0,0,.6); border:1px solid rgba(82,82,91,.15); border-radius: var(--radius); padding: .9rem; }
 .list { list-style:none; padding:0; margin:0; display:grid; gap:.35rem; }
 .list li { display:flex; justify-content:space-between; gap:.75rem; }
 .list span { color: var(--muted); }
 
 /* Habilidades */
 .chips { display:flex; flex-wrap:wrap; gap:.5rem; }
-.chip { padding:.45rem .65rem; border-radius:999px; border:1px solid rgba(148,163,184,.18); background: rgba(56,189,248,.08); color: #c7e7fb; font-weight:600; font-size:.9rem; }
+.chip { padding:.45rem .65rem; border-radius:999px; border:1px solid rgba(82,82,91,.18); background: rgba(6,182,212,.08); color: #a5f3fc; font-weight:600; font-size:.9rem; }
 
 /* Proyectos */
 .cards { display:grid; grid-template-columns: repeat(12,1fr); gap:1rem; }
-.card { grid-column: span 4; background: linear-gradient(180deg, rgba(15,23,42,.8), rgba(2,6,23,.85)); border:1px solid rgba(148,163,184,.18); border-radius: var(--radius); overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
-.thumb { aspect-ratio: 16/9; background: radial-gradient(60% 80% at 40% 20%, rgba(56,189,248,.2), rgba(2,6,23,.9) 60%), url('https://images.unsplash.com/photo-1558494949-ef010cbdcc31?q=80&w=1200&auto=format&fit=crop'); background-size:cover; background-position:center; }
+.card { grid-column: span 4; background: linear-gradient(180deg, rgba(24,24,27,.8), rgba(0,0,0,.85)); border:1px solid rgba(82,82,91,.18); border-radius: var(--radius); overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
+.thumb { aspect-ratio: 16/9; background: radial-gradient(60% 80% at 40% 20%, rgba(6,182,212,.2), rgba(0,0,0,.9) 60%), url('https://images.unsplash.com/photo-1558494949-ef010cbdcc31?q=80&w=1200&auto=format&fit=crop'); background-size:cover; background-position:center; }
 .card-body { padding:1rem; display:flex; flex-direction:column; gap:.5rem; }
 .card h3 { margin:.2rem 0; font-size:1.05rem; }
 .tags { display:flex; flex-wrap:wrap; gap:.4rem; }
-.tag { font-size:.8rem; padding:.25rem .5rem; border-radius:8px; border:1px solid rgba(148,163,184,.18); color:#cbd5e1; }
+.tag { font-size:.8rem; padding:.25rem .5rem; border-radius:8px; border:1px solid rgba(82,82,91,.18); color:#e4e4e7; }
 .card-actions { display:flex; gap:.5rem; margin-top:auto; }
 
 /* Experiencia (timeline) */
 .timeline { position:relative; padding-left:1rem; }
-.timeline::before { content:""; position:absolute; left:6px; top:0; bottom:0; width:2px; background: linear-gradient(180deg, rgba(56,189,248,.6), transparent 70%); }
+.timeline::before { content:""; position:absolute; left:6px; top:0; bottom:0; width:2px; background: linear-gradient(180deg, rgba(6,182,212,.6), transparent 70%); }
 .t-item { position:relative; margin-left:1rem; margin-bottom:1.1rem; }
-.t-item::before { content:""; position:absolute; left:-1.05rem; top:.35rem; width:10px; height:10px; border-radius:999px; background: var(--primary); box-shadow:0 0 0 3px rgba(56,189,248,.2); }
+.t-item::before { content:""; position:absolute; left:-1.05rem; top:.35rem; width:10px; height:10px; border-radius:999px; background: var(--primary); box-shadow:0 0 0 3px rgba(6,182,212,.2); }
 .t-title { font-weight:700; }
 .t-role { color: var(--muted); }
 
 /* Footer */
-footer { margin-top:3rem; border-top:1px solid rgba(148,163,184,.12); padding:2rem 0 3rem; color:var(--muted); text-align:center; }
+footer { margin-top:3rem; border-top:1px solid rgba(82,82,91,.12); padding:2rem 0 3rem; color:var(--muted); text-align:center; }
 
 /* Utilidades */
 .muted { color: var(--muted); }
@@ -146,7 +146,7 @@ footer { margin-top:3rem; border-top:1px solid rgba(148,163,184,.12); padding:2r
   .card { grid-column: span 6; }
 }
 @media (max-width: 720px) {
-  .menu { display:none; position:absolute; right:1rem; top:60px; background: rgba(15,23,42,.98); border:1px solid rgba(148,163,184,.18); border-radius:14px; padding:.5rem; flex-direction:column; width:min(260px, 90vw); }
+  .menu { display:none; position:absolute; right:1rem; top:60px; background: rgba(24,24,27,.98); border:1px solid rgba(82,82,91,.18); border-radius:14px; padding:.5rem; flex-direction:column; width:min(260px, 90vw); }
   .menu.show { display:flex; }
   .menu-toggle { display:inline-flex; cursor:pointer; }
   .hero-card .row { grid-template-columns: 1fr; }
@@ -155,6 +155,7 @@ footer { margin-top:3rem; border-top:1px solid rgba(148,163,184,.12); padding:2r
   .cards { grid-template-columns: repeat(2,1fr); }
   .card { grid-column: auto; }
   .grid-3 { grid-template-columns:1fr; }
+  .grid-2 { grid-template-columns:1fr; }
 }
 @media (max-width: 480px) {
   .cards { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- collapse `.grid-2` layouts to a single column on screens 720px wide or less
- document application usage and structure in README
- switch site to a black/zinc/cyan color palette
- load skills, projects, and education sections from standalone HTML snippets into the main page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b1ed10608327b0a7f7a658f4d892