### PR TITLE
feat: add theme mode selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Portafolio profesional de Carlos Jiménez Hirashi.
 
-Este repositorio contiene un sitio web estático construido solo con **HTML** y **CSS**.
+Este repositorio contiene un sitio web estático construido solo con **HTML** y **CSS**, ahora con selector de modo claro/oscuro/sistema.
 
 ## Archivos principales
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,11 @@
           <a href="#educacion">Educación</a>
           <a href="#contacto">Contacto</a>
         </div>
+        <div class="theme-toggle" role="group" aria-label="Cambiar tema">
+          <button class="theme-btn" data-theme="light" aria-label="Claro">☀️</button>
+          <button class="theme-btn" data-theme="dark" aria-label="Oscuro">🌙</button>
+          <button class="theme-btn" data-theme="system" aria-label="Sistema">🖥️</button>
+        </div>
       </nav>
     </div>
   </header>
@@ -148,9 +153,46 @@
     </footer>
   </main>
 
-  <script>
-    // año dinámico
-    document.getElementById('year').textContent = new Date().getFullYear();
+    <script>
+      // año dinámico
+      document.getElementById('year').textContent = new Date().getFullYear();
+
+      // tema claro/oscuro/sistema
+      const themeBtns = document.querySelectorAll('.theme-btn');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      function setTheme(mode) {
+        if (mode === 'light') {
+          document.documentElement.setAttribute('data-theme', 'light');
+        } else if (mode === 'dark') {
+          document.documentElement.removeAttribute('data-theme');
+        } else {
+          prefersDark.matches
+            ? document.documentElement.removeAttribute('data-theme')
+            : document.documentElement.setAttribute('data-theme', 'light');
+        }
+      }
+      function setActive(mode) {
+        themeBtns.forEach(btn => {
+          btn.classList.toggle('active', btn.dataset.theme === mode);
+        });
+      }
+      const savedTheme = localStorage.getItem('theme') || 'system';
+      setTheme(savedTheme);
+      setActive(savedTheme);
+      themeBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const val = btn.dataset.theme;
+          localStorage.setItem('theme', val);
+          setTheme(val);
+          setActive(val);
+        });
+      });
+      prefersDark.addEventListener('change', () => {
+        if ((localStorage.getItem('theme') || 'system') === 'system') {
+          setTheme('system');
+          setActive('system');
+        }
+      });
 
     // cerrar menú al hacer click fuera (móvil)
     document.addEventListener('click', (e) => {
@@ -161,7 +203,7 @@
       if (!clickInside) menu.classList.remove('show');
     });
 
-    // accesibilidad: cerrar con Escape
+      // accesibilidad: cerrar con Escape
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {
         document.querySelector('.menu')?.classList.remove('show');

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,32 @@
   --radius-sm: 12px;
   --radius-lg: 26px;
   --maxw: 1200px;
+  --bg-gradient: radial-gradient(1200px 600px at 20% -10%, rgba(6,182,212,.15), rgba(63,63,70,.08) 40%, transparent 60%),
+                  linear-gradient(180deg, #000, #18181b 35%);
+  --header-bg: linear-gradient(180deg, rgba(24,24,27,.85), rgba(24,24,27,.6));
+  --hover-bg: rgba(6,182,212,.08);
+  --border: rgba(82,82,91,.15);
+}
+
+:root[data-theme="light"] {
+  --bg: #fff;
+  --surface: #fff;
+  --surface-2: #f4f4f5;
+  --text: #18181b;
+  --text-link: rgba(6,182,212,.7);
+  --text-link-hover: rgba(6,182,212,.85);
+  --muted: #52525b;
+  --primary: #06b6d4;
+  --primary-2: #0891b2;
+  --accent: #06b6d4;
+  --card: #fff;
+  --ring: rgba(6,182,212,.4);
+  --shadow: 0 10px 25px rgba(0,0,0,.1);
+  --bg-gradient: radial-gradient(1200px 600px at 20% -10%, rgba(6,182,212,.15), rgba(255,255,255,.8) 40%, transparent 60%),
+                  linear-gradient(180deg, #fff, #f4f4f5 35%);
+  --header-bg: linear-gradient(180deg, rgba(255,255,255,.85), rgba(255,255,255,.6));
+  --hover-bg: rgba(6,182,212,.12);
+  --border: rgba(82,82,91,.12);
 }
 
 * { box-sizing: border-box; }
@@ -23,8 +49,7 @@ html, body { height: 100%; }
 body {
   margin: 0;
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  background: radial-gradient(1200px 600px at 20% -10%, rgba(6,182,212,.15), rgba(63,63,70,.08) 40%, transparent 60%),
-              linear-gradient(180deg, #000, #18181b 35%);
+  background: var(--bg-gradient);
   background-attachment: fixed;
   background-repeat: no-repeat;
   background-size: cover;
@@ -39,8 +64,8 @@ body {
 header {
   position: sticky; top: 0; z-index: 50;
   backdrop-filter: blur(12px);
-  background: linear-gradient(180deg, rgba(24,24,27,.85), rgba(24,24,27,.6));
-  border-bottom: 1px solid rgba(82,82,91,.12);
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--border);
 }
 a {
   color: var(--text-link);
@@ -52,6 +77,7 @@ a:hover, a:focus {
   outline: none;
 }
 .nav { display:flex; align-items:center; justify-content:space-between; padding: .8rem 0; }
+.nav nav { display:flex; align-items:center; }
 .brand { display:flex; align-items:center; gap:.75rem; text-decoration:none; color:var(--text); }
 .brand-logo {
   width:40px; height:40px; border-radius:12px;
@@ -62,9 +88,22 @@ a:hover, a:focus {
 
 .menu { display:flex; align-items:center; gap: 1rem; }
 .menu a { color: var(--muted); text-decoration:none; font-weight:500; padding:.5rem .75rem; border-radius:10px; }
-.menu a:hover, .menu a:focus { color: var(--text); background: rgba(6,182,212,.08); outline: none; }
+.menu a:hover, .menu a:focus { color: var(--text); background: var(--hover-bg); outline: none; }
 
 .menu-toggle { display:none; background:transparent; border:none; color:var(--text); font-size:1.25rem; }
+
+.theme-toggle { display:flex; margin-left:1rem; gap:.25rem; }
+.theme-btn {
+  width:28px; height:28px;
+  display:flex; align-items:center; justify-content:center;
+  border:1px solid var(--border);
+  border-radius:8px;
+  background: var(--surface);
+  color: var(--text);
+  font-size:.9rem; padding:0; cursor:pointer;
+}
+.theme-btn:hover,
+.theme-btn.active { background: var(--hover-bg); }
 
 /* Hero */
 .hero { padding: 4.5rem 0 3rem; }
@@ -76,7 +115,7 @@ a:hover, a:focus {
 .cta { display:flex; gap:.75rem; margin-top:1.2rem; flex-wrap:wrap; }
 .btn {
   display:inline-flex; align-items:center; gap:.5rem; text-decoration:none; font-weight:600;
-  padding:.8rem 1rem; border-radius:12px; border:1px solid rgba(82,82,91,.18);
+  padding:.8rem 1rem; border-radius:12px; border:1px solid var(--border);
   background: linear-gradient(180deg, rgba(6,182,212,.15), rgba(6,182,212,.05)); color: var(--text);
   box-shadow: var(--shadow);
 }
@@ -84,13 +123,13 @@ a:hover, a:focus {
 .btn.alt { background: linear-gradient(180deg, rgba(63,63,70,.15), rgba(63,63,70,.05)); }
 
 .hero-card {
-  background: linear-gradient(180deg, rgba(24,24,27,.9), rgba(0,0,0,.85));
-  border: 1px solid rgba(82,82,91,.18);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 1.25rem; box-shadow: var(--shadow);
 }
 .hero-card .row { display:grid; grid-template-columns: 1fr 1fr; gap:.75rem; }
-.stat { background: rgba(0,0,0,.6); border:1px solid rgba(82,82,91,.15); padding:.9rem; border-radius:14px; }
+.stat { background: var(--surface-2); border:1px solid var(--border); padding:.9rem; border-radius:14px; }
 .stat b { display:block; font-size:1.1rem; }
 .small { color: var(--muted); font-size:.9rem; }
 
@@ -100,28 +139,28 @@ section { padding: 2.5rem 0 0; }
 .section-grid { display:grid; grid-template-columns: repeat(12, 1fr); gap:1.2rem; }
 
 /* Sobre mí */
-.about { grid-column: span 7; background: linear-gradient(180deg, rgba(0,0,0,.7), rgba(24,24,27,.75)); border:1px solid rgba(82,82,91,.15); border-radius: var(--radius); padding:1rem; }
-.about p { margin:.5rem 0; color: #d4d4d8; }
+.about { grid-column: span 7; background: var(--surface); border:1px solid var(--border); border-radius: var(--radius); padding:1rem; }
+.about p { margin:.5rem 0; color: var(--text); }
 .meta { grid-column: span 5; display:grid; gap:.75rem; }
-.meta-card { background: rgba(0,0,0,.6); border:1px solid rgba(82,82,91,.15); border-radius: var(--radius); padding: .9rem; }
+.meta-card { background: var(--surface); border:1px solid var(--border); border-radius: var(--radius); padding: .9rem; }
 .list { list-style:none; padding:0; margin:0; display:grid; gap:.35rem; }
 .list li { display:flex; justify-content:space-between; gap:.75rem; }
 .list span { color: var(--muted); }
 
 /* Habilidades */
 .chips { display:flex; flex-wrap:wrap; gap:.5rem; }
-.chip { padding:.45rem .65rem; border-radius:999px; border:1px solid rgba(82,82,91,.18); background: rgba(6,182,212,.08); color: #a5f3fc; font-weight:600; font-size:.9rem; }
+.chip { padding:.45rem .65rem; border-radius:999px; border:1px solid var(--border); background: var(--hover-bg); color: var(--primary-2); font-weight:600; font-size:.9rem; }
 
 /* Proyectos */
 .cards { display:grid; grid-template-columns: repeat(12,1fr); gap:1rem; }
-.card { grid-column: span 4; background: linear-gradient(180deg, rgba(24,24,27,.8), rgba(0,0,0,.85)); border:1px solid rgba(82,82,91,.18); border-radius: var(--radius); overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
+.card { grid-column: span 4; background: var(--surface); border:1px solid var(--border); border-radius: var(--radius); overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
 
 .thumb { aspect-ratio: 16/9; background: radial-gradient(60% 80% at 40% 20%, rgba(6,182,212,.2), rgba(0,0,0,.6) 60%), url('https://images.unsplash.com/photo-1542903660-eedba2cda473?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'); background-size:cover; background-position:center; }
 
 .card-body { padding:1rem; display:flex; flex-direction:column; gap:.5rem; }
 .card h3 { margin:.2rem 0; font-size:1.05rem; }
 .tags { display:flex; flex-wrap:wrap; gap:.4rem; }
-.tag { font-size:.8rem; padding:.25rem .5rem; border-radius:8px; border:1px solid rgba(82,82,91,.18); color:#e4e4e7; }
+.tag { font-size:.8rem; padding:.25rem .5rem; border-radius:8px; border:1px solid var(--border); color:var(--text); }
 .card-actions { display:flex; gap:.5rem; margin-top:auto; }
 
 /* Experiencia (timeline) */
@@ -133,7 +172,7 @@ section { padding: 2.5rem 0 0; }
 .t-role { color: var(--muted); }
 
 /* Footer */
-footer { margin-top:3rem; border-top:1px solid rgba(82,82,91,.12); padding:2rem 0 3rem; color:var(--muted); text-align:center; }
+footer { margin-top:3rem; border-top:1px solid var(--border); padding:2rem 0 3rem; color:var(--muted); text-align:center; }
 
 /* Utilidades */
 .muted { color: var(--muted); }
@@ -148,7 +187,7 @@ footer { margin-top:3rem; border-top:1px solid rgba(82,82,91,.12); padding:2rem 
   .card { grid-column: span 6; }
 }
 @media (max-width: 720px) {
-  .menu { display:none; position:absolute; right:1rem; top:60px; background: rgba(24,24,27,.98); border:1px solid rgba(82,82,91,.18); border-radius:14px; padding:.5rem; flex-direction:column; width:min(260px, 90vw); }
+  .menu { display:none; position:absolute; right:1rem; top:60px; background: var(--surface); border:1px solid var(--border); border-radius:14px; padding:.5rem; flex-direction:column; width:min(260px, 90vw); }
   .menu.show { display:flex; }
   .menu-toggle { display:inline-flex; cursor:pointer; }
   .hero-card .row { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- add light/dark/system theme selector with local storage
- style components to support light theme
- shrink theme selector and replace text with icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a429db70c08327b2c48632ae82fecf