### PR TITLE
feat: cargar imágenes de proyectos desde JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,9 +190,10 @@
       .then(data => {
         const section = document.getElementById('proyectos');
         let html = '<h2 class="section-title">🧩 Proyectos</h2><div class="cards">';
-        data.forEach(p => {
-          html += `\n          <article class="card">\n            <div class="thumb" role="img" aria-label="${p.thumb}"></div>\n            <div class="card-body">\n              <h3>${p.titulo}</h3>\n              <p class="muted">${p.descripcion}</p>\n              <div class="tags">\n                ${p.tags.map(tag => `<span class=\"tag\">${tag}</span>`).join('')}\n              </div>\n              <div class="card-actions">\n                <a class="btn" href="${p.codigo}" target="_blank" rel="noopener">Código</a>\n                ${p.demo ? `<a class=\"btn alt\" href="${p.demo}" target="_blank" rel="noopener">Demo</a>` : ''}\n              </div>\n            </div>\n          </article>`;
-        });
+          data.forEach(p => {
+            const thumbStyle = p.imagen ? ` style="background-image: radial-gradient(60% 80% at 40% 20%, rgba(6,182,212,.2), rgba(0,0,0,.6) 60%), url('${p.imagen}');"` : '';
+            html += `\n          <article class="card">\n            <div class="thumb"${thumbStyle} role="img" aria-label="${p.thumb}"></div>\n            <div class="card-body">\n              <h3>${p.titulo}</h3>\n              <p class="muted">${p.descripcion}</p>\n              <div class="tags">\n                ${p.tags.map(tag => `<span class=\"tag\">${tag}</span>`).join('')}\n              </div>\n              <div class="card-actions">\n                <a class="btn" href="${p.codigo}" target="_blank" rel="noopener">Código</a>\n                ${p.demo ? `<a class=\"btn alt\" href="${p.demo}" target="_blank" rel="noopener">Demo</a>` : ''}\n              </div>\n            </div>\n          </article>`;
+          });
         html += '</div><p class="small muted" style="margin-top:.6rem">Tip: puedes reemplazar las imágenes de portada (Unsplash) con capturas de tus notebooks o dashboards.</p>';
         section.innerHTML = html;
       });

--- a/main.js
+++ b/main.js
@@ -83,7 +83,24 @@ function buildProjects(data) {
   const section = document.getElementById('proyectos');
   let html = '<h2 class="section-title">🧩 Proyectos</h2><div class="cards">';
   data.forEach(p => {
-    html += `\n        <article class="card">\n          <div class="thumb" role="img" aria-label="${p.thumb}"></div>\n          <div class="card-body">\n            <h3>${p.titulo}</h3>\n            <p class="muted">${p.descripcion}</p>\n            <div class="tags">\n              ${p.tags.map(tag => `<span class=\"tag\">${tag}</span>`).join('')}\n            </div>\n            <div class="card-actions">\n              <a class="btn" href="${p.codigo}" target="_blank" rel="noopener">Código</a>\n              ${p.demo ? `<a class=\"btn alt\" href="${p.demo}" target="_blank" rel="noopener">Demo</a>` : ''}\n            </div>\n          </div>\n        </article>`;
+    const thumbStyle = p.imagen
+      ? ` style="background-image: radial-gradient(60% 80% at 40% 20%, rgba(6,182,212,.2), rgba(0,0,0,.6) 60%), url('${p.imagen}');"`
+      : '';
+    html += `
+        <article class="card">
+          <div class="thumb"${thumbStyle} role="img" aria-label="${p.thumb}"></div>
+          <div class="card-body">
+            <h3>${p.titulo}</h3>
+            <p class="muted">${p.descripcion}</p>
+            <div class="tags">
+              ${p.tags.map(tag => `<span class=\"tag\">${tag}</span>`).join('')}
+            </div>
+            <div class="card-actions">
+              <a class="btn" href="${p.codigo}" target="_blank" rel="noopener">Código</a>
+      ${p.demo ? `<a class=\"btn alt\" href="${p.demo}" target="_blank" rel="noopener">Demo</a>` : ''}
+            </div>
+          </div>
+        </article>`;
   });
   html += '</div><p class="small muted" style="margin-top:.6rem">Tip: puedes reemplazar las imágenes de portada (Unsplash) con capturas de tus notebooks o dashboards.</p>';
   section.innerHTML = html;

--- a/proyectos.json
+++ b/proyectos.json
@@ -9,7 +9,8 @@
             "Matplotlib",
             "Jupyter"
         ],
-        "codigo": "https://github.com/cjhirashi/proyecto-sprint-5"
+        "codigo": "https://github.com/cjhirashi/proyecto-sprint-5",
+        "imagen": "https://images.unsplash.com/photo-1529101091764-c3526daf38fe?auto=format&fit=crop&w=800&q=80"
     },
     {
         "thumb": "Asistente GPT",
@@ -20,7 +21,8 @@
             "pandas",
             "Jupyter"
         ],
-        "codigo": "https://github.com/cjhirashi/proyecto-sprint-6"
+        "codigo": "https://github.com/cjhirashi/proyecto-sprint-6",
+        "imagen": "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80"
     },
     {
         "thumb": "An\u00e1lisis de datos",


### PR DESCRIPTION
## Summary
- permite definir una URL de imagen para cada proyecto mediante el campo `imagen`
- muestra una imagen genérica cuando no se especifica la URL
- actualiza los constructores de tarjetas en `index.html` y `main.js`

## Testing
- `node --check main.js`
- `npm test` *(falla: no se encontró `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a43ce8908883279ea58c376b029af9